### PR TITLE
Manage non existent processes in check status end-points

### DIFF
--- a/services/csw-harvester/src/main/java/geocat/database/service/HarvestJobService.java
+++ b/services/csw-harvester/src/main/java/geocat/database/service/HarvestJobService.java
@@ -77,8 +77,8 @@ public class HarvestJobService {
         }
     }
 
-    public HarvestJob getById(String id) {
-        return harvestJobRepo.findById(id).get();
+    public Optional<HarvestJob> getById(String id) {
+        return harvestJobRepo.findById(id);
     }
 
     public Optional<HarvestJob> getLastCompletedHarvestJobIdByLongTermTag(String longTermTag) {

--- a/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/harvest/EventProcessor_ActualHarvestStartCommand.java
+++ b/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/harvest/EventProcessor_ActualHarvestStartCommand.java
@@ -63,7 +63,7 @@ public class EventProcessor_ActualHarvestStartCommand extends BaseEventProcessor
         List<Event> result = new ArrayList<>();
         String harvestId = getInitiatingEvent().getHarvesterId();
 
-        HarvestJob harvestJob = harvestJobService.getById(harvestId);
+        HarvestJob harvestJob = harvestJobService.getById(harvestId).get();
         List<EndpointJob> endpointJobs = harvestJobService.getEndpointJobs(harvestId);
 
         for (EndpointJob job : endpointJobs) {

--- a/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/harvest/EventProcessor_EndpointHarvestComplete.java
+++ b/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/harvest/EventProcessor_EndpointHarvestComplete.java
@@ -55,7 +55,7 @@ public class EventProcessor_EndpointHarvestComplete extends BaseEventProcessor<E
             boolean thisJobDone = job.getState() == EndpointJobState.RECORDS_RECEIVED;
             allDone = allDone && thisJobDone;
         }
-        HarvestJob harvestJob = harvestJobService.getById(getInitiatingEvent().getHarvestId());
+        HarvestJob harvestJob = harvestJobService.getById(getInitiatingEvent().getHarvestId()).get();
         EndpointJob endpointJob = endpointJobService.getById(getInitiatingEvent().getEndPointId());
         getRecordsResponseEvaluator.evaluate_duplicateUUIDs(harvestJob, endpointJob);
         return this;

--- a/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/harvest/EventProcessor_GetRecordsCommand.java
+++ b/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/harvest/EventProcessor_GetRecordsCommand.java
@@ -70,7 +70,7 @@ public class EventProcessor_GetRecordsCommand extends BaseEventProcessor<GetReco
         //logger.debug("finish parse xml");
 
         GetRecordsResponseInfo info = new GetRecordsResponseInfo(xmlParsed);
-        HarvestJob harvestJob = harvestJobService.getById(e.getHarvesterId());
+        HarvestJob harvestJob = harvestJobService.getById(e.getHarvesterId()).get();
         EndpointJob endpointJob = endpointJobService.getById(e.getEndPointId());
         RecordSet recordSet = recordSetService.getById(e.getRecordSetId());
 

--- a/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/main/EventProcessor_HarvestAbortEvent.java
+++ b/services/csw-harvester/src/main/java/geocat/eventprocessor/processors/main/EventProcessor_HarvestAbortEvent.java
@@ -35,7 +35,7 @@ public class EventProcessor_HarvestAbortEvent extends BaseEventProcessor<Harvest
     public EventProcessor_HarvestAbortEvent internalProcessing() {
         String processID = getInitiatingEvent().getProcessID();
         logger.warn("attempting to user abort for " + processID);
-        HarvestJob job = harvestJobService.getById(processID);
+        HarvestJob job = harvestJobService.getById(processID).get();
         if ((job.getState() != HarvestJobState.COMPLETE)
                 && (job.getState() != HarvestJobState.ERROR)
                 && (job.getState() != HarvestJobState.USERABORT)) {

--- a/services/csw-harvester/src/main/java/geocat/model/HarvestStatus.java
+++ b/services/csw-harvester/src/main/java/geocat/model/HarvestStatus.java
@@ -1,6 +1,7 @@
 package geocat.model;
 
 import geocat.database.entities.HarvestJob;
+import geocat.database.entities.HarvestJobState;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,13 @@ public class HarvestStatus {
     public List<EndpointStatus> endpoints;
 
 
+    private HarvestStatus(String processID) {
+        this.processID = processID;
+        endpoints = new ArrayList<>();
+        stackTraces = new ArrayList<>();
+        errorMessage = new ArrayList<>();
+    }
+
     public HarvestStatus(HarvestJob job) {
         this.processID = job.getJobId();
         this.url = job.getInitialUrl();
@@ -28,5 +36,12 @@ public class HarvestStatus {
         endpoints = new ArrayList<>();
         stackTraces = new ArrayList<>();
         errorMessage = new ArrayList<>();
+    }
+
+    public static HarvestStatus createHarvestStatusNoProcessId(String processID) {
+        HarvestStatus harvestStatus = new HarvestStatus(processID);
+        harvestStatus.state = HarvestJobState.ERROR.toString();
+        harvestStatus.errorMessage.add(String.format("Harvester with processID %s doesn't exist", processID));
+        return harvestStatus;
     }
 }

--- a/services/ingester/src/main/java/com/geocat/ingester/model/ingester/IngestStatus.java
+++ b/services/ingester/src/main/java/com/geocat/ingester/model/ingester/IngestStatus.java
@@ -1,6 +1,9 @@
 package com.geocat.ingester.model.ingester;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class IngestStatus {
     public String processID;
     public String harvesterJobId;
@@ -11,6 +14,13 @@ public class IngestStatus {
     public long numberOfRecordsIngested;
     public long numberOfRecordsIndexed;
 
+    public List<String> errorMessage;
+
+    private IngestStatus(String processID) {
+        this.processID = processID;
+        errorMessage = new ArrayList<>();
+    }
+
     public IngestStatus(IngestJob job) {
         this.processID = job.getJobId();
         this.totalRecords = (job.getTotalRecords() == null ? 0 : job.getTotalRecords());
@@ -20,5 +30,14 @@ public class IngestStatus {
         this.state = job.getState().toString();
         this.createTimeUTC = job.getCreateTimeUTC().toInstant().toString();
         this.lastUpdateUTC = job.getLastUpdateUTC().toInstant().toString();
+        this.errorMessage = new ArrayList<>();
+    }
+
+    public static IngestStatus createIngestStatusNoProcessId(String processID) {
+        IngestStatus ingestStatus = new IngestStatus(processID);
+        ingestStatus.state = IngestJobState.ERROR.toString();
+        ingestStatus.errorMessage.add(String.format("Ingester with processID %s doesn't exist", processID));
+
+        return ingestStatus;
     }
 }

--- a/services/ingester/src/main/java/com/geocat/ingester/service/GetStatusService.java
+++ b/services/ingester/src/main/java/com/geocat/ingester/service/GetStatusService.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 @Scope("prototype")
 public class GetStatusService {
@@ -14,9 +16,15 @@ public class GetStatusService {
     IngestJobService ingestJobService;
 
     public IngestStatus getStatus(String processId) {
-        IngestJob job = ingestJobService.getById(processId);
+        Optional<IngestJob> jobOptional = ingestJobService.getById(processId);
 
-        IngestStatus result = new IngestStatus(job);
+        IngestStatus result;
+
+        if (jobOptional.isPresent()) {
+            result = new IngestStatus(jobOptional.get());
+        } else {
+            result = IngestStatus.createIngestStatusNoProcessId(processId);
+        }
 
         return result;
     }

--- a/services/ingester/src/main/java/com/geocat/ingester/service/IngestJobService.java
+++ b/services/ingester/src/main/java/com/geocat/ingester/service/IngestJobService.java
@@ -77,7 +77,7 @@ public class IngestJobService {
         return ingestJobRepo.save(job);
     }
 
-    public IngestJob getById(String id) {
-        return ingestJobRepo.findById(id).get();
+    public Optional<IngestJob> getById(String id) {
+        return ingestJobRepo.findById(id);
     }
 }


### PR DESCRIPTION
Return the status of the components with a error to indicate that the process id provided doesn't exist, so the applications using the end-points can manage these cases. 

Without the change the log file can be full of exceptions like this:

```
csw-harvester  | java.util.NoSuchElementException: No value present
csw-harvester  | 	at java.util.Optional.get(Optional.java:135)
csw-harvester  | 	at geocat.database.service.HarvestJobService.getById(HarvestJobService.java:81)
csw-harvester  | 	at geocat.service.GetStatusService.getStatus(GetStatusService.java:48)
```
